### PR TITLE
[BUGFIX] google_api.py `totalResults` located outside ['queries']['request']

### DIFF
--- a/dorkbot/indexers/google_api.py
+++ b/dorkbot/indexers/google_api.py
@@ -74,9 +74,9 @@ def issue_request(data):
                 sys.exit(1)
 
     items = []
+    if int(response['searchInformation']['totalResults']) == 0:
+        return []
     for request in response["queries"]["request"]:
-        if int(request["totalResults"]) == 0:
-            return []
         for item in response["items"]:
             items.append(urlparse(item["link"]).geturl())
 


### PR DESCRIPTION
Using `google_api` indexer I get below traceback:
```
Traceback (most recent call last):
  File "./dorkbot.py", line 742, in <module>
    main()
  File "./dorkbot.py", line 73, in main
    index(db, blacklist, load_module("indexers", args.indexer), args, indexer_options)
  File "./dorkbot.py", line 212, in index
    urls = indexer.run(options)
  File "~/dorkbot/dorkbot/indexers/google_api.py", line 17, in run
    results = get_results(options)
  File "~/dorkbot/dorkbot/indexers/google_api.py", line 34, in get_results
    items = issue_request(data)
  File "~/dorkbot/dorkbot/indexers/google_api.py", line 79, in issue_request
    if int(request["totalResults"]) == 0:
KeyError: 'totalResults'
```
Looking manually at Google CSE json response, the ["totalResults"] is actually outside  ["queries"]["request"]
Maybe CSE change json scheme at some point? Anyway, quick fix sort up the problem
