### PR TITLE
Remove unused imports

### DIFF
--- a/dorkbot/indexers/bing_api.py
+++ b/dorkbot/indexers/bing_api.py
@@ -1,7 +1,5 @@
-import argparse
 import json
 import logging
-import sys
 import time
 from urllib.error import HTTPError
 from urllib.parse import urlencode, urlparse

--- a/dorkbot/indexers/commoncrawl.py
+++ b/dorkbot/indexers/commoncrawl.py
@@ -1,4 +1,3 @@
-import argparse
 import json
 import logging
 import random

--- a/dorkbot/indexers/example.py
+++ b/dorkbot/indexers/example.py
@@ -1,4 +1,3 @@
-import argparse
 from urllib.parse import urlparse
 
 

--- a/dorkbot/indexers/google.py
+++ b/dorkbot/indexers/google.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 import os
 import subprocess

--- a/dorkbot/indexers/google_api.py
+++ b/dorkbot/indexers/google_api.py
@@ -1,4 +1,3 @@
-import argparse
 import json
 import logging
 import sys

--- a/dorkbot/indexers/pywb.py
+++ b/dorkbot/indexers/pywb.py
@@ -1,4 +1,3 @@
-import argparse
 import json
 import logging
 import random

--- a/dorkbot/indexers/stdin.py
+++ b/dorkbot/indexers/stdin.py
@@ -1,4 +1,3 @@
-import argparse
 import io
 import logging
 import sys

--- a/dorkbot/indexers/wayback.py
+++ b/dorkbot/indexers/wayback.py
@@ -1,4 +1,3 @@
-import argparse
 import json
 import logging
 import random

--- a/dorkbot/scanners/arachni.py
+++ b/dorkbot/scanners/arachni.py
@@ -1,4 +1,3 @@
-import argparse
 import io
 import json
 import logging

--- a/dorkbot/scanners/wapiti.py
+++ b/dorkbot/scanners/wapiti.py
@@ -1,4 +1,3 @@
-import argparse
 import io
 import json
 import logging


### PR DESCRIPTION
This PR removes unused imports identified by a flake8 run:

```
 flake8 . | grep 401
./dorkbot/__init__.py:1:1: F401 '._version.__version__' imported but unused
./dorkbot/indexers/bing_api.py:1:1: F401 'argparse' imported but unused
./dorkbot/indexers/bing_api.py:4:1: F401 'sys' imported but unused
./dorkbot/indexers/commoncrawl.py:1:1: F401 'argparse' imported but unused
./dorkbot/indexers/example.py:1:1: F401 'argparse' imported but unused
./dorkbot/indexers/google.py:1:1: F401 'argparse' imported but unused
./dorkbot/indexers/google_api.py:1:1: F401 'argparse' imported but unused
./dorkbot/indexers/pywb.py:1:1: F401 'argparse' imported but unused
./dorkbot/indexers/stdin.py:1:1: F401 'argparse' imported but unused
./dorkbot/indexers/wayback.py:1:1: F401 'argparse' imported but unused
./dorkbot/scanners/arachni.py:1:1: F401 'argparse' imported but unused
./dorkbot/scanners/wapiti.py:1:1: F401 'argparse' imported but unused
```