### PR TITLE
Update google-api indexer

### DIFF
--- a/dorkbot/indexers/google_api.py
+++ b/dorkbot/indexers/google_api.py
@@ -82,10 +82,10 @@ def issue_request(data):
                 sys.exit(1)
 
     items = []
-    if int(response['searchInformation']['totalResults']) == 0:
+    # https://developers.google.com/custom-search/v1/reference/rest/v1/Search
+    if int(response['searchInformation'].get('totalResults', 0)) == 0:
         return []
-    for request in response["queries"]["request"]:
-        for item in response["items"]:
-            items.append(urlparse(item["link"]).geturl())
+    for item in response["items"]:
+        items.append(urlparse(item["link"]).geturl())
 
     return items


### PR DESCRIPTION
Resolves https://github.com/utiso/dorkbot/issues/19

Update google-api indexer:
  - Fix `totalResults` not present in the response search information case.
  - Remove unnecessary loop over queries request field while gathering response items.

The no longer needed `for request in response["queries"]["request"]` line is a leftover after PR #16 merge.